### PR TITLE
docs: add official Pump SDK documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,83 @@
 
 [Pump fee program docs](docs/FEE_PROGRAM_README.md)
 
+## Official Pump SDK
+
+The official Pump program SDK is available on npm: [@pump-fun/pump-sdk](https://www.npmjs.com/package/@pump-fun/pump-sdk)
+
+### Installation
+
+```bash
+npm install @pump-fun/pump-sdk
+```
+
+### Basic Setup
+
+```typescript
+import { PumpSdk, OnlinePumpSdk } from '@pump-fun/pump-sdk'
+import { Connection } from '@solana/web3.js'
+
+const connection = new Connection(
+  "https://api.devnet.solana.com",
+  "confirmed",
+);
+const sdk = new PumpSdk();
+const onlineSdk = new OnlinePumpSdk(connection);
+```
+
+### Coin Creation
+
+```typescript
+const mint = PublicKey.unique()
+const creator = PublicKey.unique()
+const user = PublicKey.unique()
+const mayhemMode = false
+const cashback = false
+
+const instruction = await pumpSdk.createV2Instruction({
+  mint,
+  name: 'name',
+  symbol: 'symbol',
+  uri: 'uri',
+  creator,
+  user,
+  mayhemMode,
+  cashback
+})
+```
+
+### Creating and Buying in the Same Transaction
+
+```typescript
+const mint = PublicKey.unique()
+const user = PublicKey.unique()
+const creator = PublicKey.unique()
+const global = await onlinePumpSdk.fetchGlobal()
+const solAmount = new BN(0.1 * 10 ** 9) // 0.1 SOL
+
+const { bondingCurve } = await onlinePumpSdk.fetchBuyState(mint, user)
+
+const createIx = await pumpSdk.createV2AndBuyInstructions({
+  global,
+  mint,
+  name: 'name',
+  symbol: 'symbol',
+  uri: 'uri',
+  creator,
+  user,
+  amount: getBuyTokenAmountFromSolAmount({
+    global,
+    feeConfig: null,
+    mintSupply: null,
+    bondingCurve,
+    amount: solAmount
+  }),
+  solAmount,
+  mayhemMode: false,
+  cashback: false
+})
+```
+
 ## Other documentation
 
 - [Pump Program](docs/PUMP_PROGRAM_README.md)


### PR DESCRIPTION
## Summary
Adds documentation for the official [@pump-fun/pump-sdk](https://www.npmjs.com/package/@pump-fun/pump-sdk) package to the README.

## Changes
- Added SDK installation instructions
- Added basic setup examples with `PumpSdk` and `OnlinePumpSdk`
- Added coin creation example using `createV2Instruction`
- Added combined create and buy transaction example using `createV2AndBuyInstructions`

Closes #25

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change (README examples/links) with no runtime or security impact.
> 
> **Overview**
> Adds an **“Official Pump SDK”** section to `README.md` linking to `@pump-fun/pump-sdk`, with npm install instructions and TypeScript examples for initializing `PumpSdk`/`OnlinePumpSdk`.
> 
> Includes usage snippets for **coin creation** via `createV2Instruction` and for **creating + buying in one transaction** via `createV2AndBuyInstructions` (including fetching global state and calculating buy amounts).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a70162ff5876f1f7c0de4101e2c05e62810472a9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->