### PR TITLE
correct this misleading description

### DIFF
--- a/docs/PUMP_CASHBACK_README.md
+++ b/docs/PUMP_CASHBACK_README.md
@@ -15,7 +15,7 @@ You can also use our Typescript SDKs for easier integration:
 ## Changes to Instructions
 
 Cashback is only given to the user if the buy/sell instruction appends the proper remaining accounts.
-If the coin traded is a cashback coin but the cashback remaining accounts are now added, then the creator fee will
+If the coin traded is a cashback coin but the cashback remaining accounts are not added, then the creator fee will
 go to the creator as it normally would. 
 
 ### Bonding Curve Buy Instructions


### PR DESCRIPTION
The current description is misleading. Please check it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that corrects when cashback is applied; no runtime behavior or APIs are modified.
> 
> **Overview**
> Clarifies in `docs/PUMP_CASHBACK_README.md` that **cashback is only applied when the required remaining accounts are provided**; otherwise (even for a cashback-enabled coin) the creator fee is paid to the creator as usual.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5eeed8058b5098dfc71822cc840d96343d2f4896. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->