### PR TITLE
feat: add rust examples for public docs

### DIFF
--- a/docs/instructions/COLLECT_CREATOR_FEE.md
+++ b/docs/instructions/COLLECT_CREATOR_FEE.md
@@ -49,3 +49,47 @@ The `collect_coin_creator_fee` instruction sweeps coin creator fees that have ac
 | 6   | `coin_creator_token_account`   | Token account for `quote_mint` owned by `coin_creator`, using `quote_token_program`. Destination of the transfer.                                             | Must be initialized.        |
 | 7   | `event_authority`              | Pump AMM PDA: seeds `[b"__event_authority"]`.                                                                                                                 | -                           |
 | 8   | `program`                      | Pump AMM program account.                                                                                                                                     | -                           |
+
+## Rust SDK
+
+Sweep the bonding curve creator vault, and (if the coin has graduated) the AMM coin creator vault. `quote_mint` can be wrapped SOL or USDC, pass the matching token program as `quote_token_program`.
+
+```rust
+use pump_rust_client::accounts::pump_amm::decode_pool;
+use pump_rust_client::constants::NATIVE_MINT;
+use pump_rust_client::{constants, pda, PumpSdk};
+use solana_sdk::compute_budget::ComputeBudgetInstruction;
+
+let sdk = PumpSdk::new();
+
+// For SOL-paired coins:
+let quote_mint = NATIVE_MINT;
+let quote_token_program = constants::SPL_TOKEN_PROGRAM_ID;
+// For USDC-paired coins, set `quote_mint` to the USDC mint instead
+// (token program remains `SPL_TOKEN_PROGRAM_ID`).
+
+let mut ixs = vec![ComputeBudgetInstruction::set_compute_unit_limit(200_000)];
+
+if graduated {
+    let pool_creator = pda::pump::pool_authority(&mint).0;
+    let pool_address = pda::pump_amm::pool(0, &pool_creator, &mint, &quote_mint).0;
+    let pool = decode_pool(&rpc.get_account(&pool_address).await?.data)?;
+
+    ixs.extend(sdk.collect_coin_creator_fee_instructions(
+        payer,
+        pool.coin_creator,
+        quote_mint,
+        quote_token_program,
+        true,
+    ));
+}
+
+// 2. Sweep the bonding curve creator vault to `creator`.
+ixs.extend(sdk.collect_creator_fee_v2_instructions(
+    payer,
+    creator,
+    quote_mint,
+    quote_token_program,
+    true,
+));
+```

--- a/docs/instructions/CREATOR_FEE_SHARING.md
+++ b/docs/instructions/CREATOR_FEE_SHARING.md
@@ -284,3 +284,64 @@ const distributeIx = await PUMP_SDK.distributeCreatorFeesV2({
   quoteTokenProgram,
 });
 ```
+
+## Rust SDK
+
+Sweep AMM-side creator fees into the bonding curve vault, then distribute them to the shareholders. `quote_mint` can be wrapped SOL or USDC, pass the matching token program as `quote_token_program`.
+
+```rust
+use pump_rust_client::accounts::decode_sharing_config;
+use pump_rust_client::accounts::pump_amm::decode_pool;
+use pump_rust_client::constants::NATIVE_MINT;
+use pump_rust_client::{constants, pda, PumpSdk};
+use solana_sdk::compute_budget::ComputeBudgetInstruction;
+use solana_sdk::pubkey::Pubkey;
+
+let sdk = PumpSdk::new();
+
+// For SOL-paired coins:
+let quote_mint = NATIVE_MINT;
+let quote_token_program = constants::SPL_TOKEN_PROGRAM_ID;
+// For USDC-paired coins, set `quote_mint` to the USDC mint instead
+// (token program remains `SPL_TOKEN_PROGRAM_ID`).
+
+let pool_creator = pda::pump::pool_authority(&mint).0;
+let pool_address = pda::pump_amm::pool(0, &pool_creator, &mint, &quote_mint).0;
+let pool = decode_pool(&rpc.get_account(&pool_address).await?.data)?;
+
+// 1. (Graduated coins only.) Sweep AMM-side creator fees into the bonding
+//    curve creator vault.
+let transfer_ix = sdk.transfer_creator_fees_to_pump_v2_instruction(
+    payer,
+    pool.coin_creator,
+    quote_mint,
+    quote_token_program,
+);
+
+// 2. Distribute the bonding curve creator vault to the shareholders.
+let sharing_config = decode_sharing_config(
+    &rpc.get_account(&pda::pump::sharing_config(&mint).0).await?.data,
+)?;
+let shareholders: Vec<Pubkey> = sharing_config
+    .shareholders
+    .iter()
+    .map(|s| s.address)
+    .collect();
+
+let bc = client.fetch_bonding_curve(&mint).await?;
+
+let mut ixs = vec![
+    ComputeBudgetInstruction::set_compute_unit_limit(400_000),
+    transfer_ix,
+];
+ixs.extend(sdk.distribute_creator_fees_v2_instructions(
+    payer,
+    mint,
+    bc.creator,
+    quote_mint,
+    quote_token_program,
+    false,
+    true,
+    &shareholders,
+));
+```


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes adding Rust code examples; no on-chain or SDK logic is modified.
> 
> **Overview**
> Adds **Rust SDK usage examples** to the public instruction docs for creator fees.
> 
> `COLLECT_CREATOR_FEE.md` now shows how to build instructions to sweep bonding-curve fees via `collect_creator_fee_v2` and, for graduated coins, AMM-side fees via `collect_coin_creator_fee`. `CREATOR_FEE_SHARING.md` adds a Rust flow to `transfer_creator_fees_to_pump_v2` and then `distribute_creator_fees_v2`, including fetching `sharing_config` and deriving the shareholder list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a313d980b16f4733a6244734cdc5990fd9c3f8a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->